### PR TITLE
Report active status when the charm is ready

### DIFF
--- a/reactive/kubeflow_seldon_cluster_manager.py
+++ b/reactive/kubeflow_seldon_cluster_manager.py
@@ -10,6 +10,11 @@ from charms.reactive import when, when_not
 from charms import layer
 
 
+@when('charm.kubeflow-seldon-cluster-manager.started')
+def charm_ready():
+    layer.status.active('')
+
+
 @when('config.changed')
 def update_model():
     clear_flag('charm.kubeflow-seldon-cluster-manager.started')


### PR DESCRIPTION
When charm has pushed the pod spec, report status as active so juju can correctly reflect the unit status when the container has started.